### PR TITLE
Fix CI: galaxy.yml author length and ansible-doc sanity

### DIFF
--- a/changelogs/fragments/fix-ci-sanity-and-metadata.yml
+++ b/changelogs/fragments/fix-ci-sanity-and-metadata.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - galaxy.yml - Shorten author string to comply with galaxy-importer 64-char limit.
+  - netbox_event_rule - Move endpoint registration into main() to fix ansible-doc sanity test.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@ name: netbox
 version: 1.1.0
 readme: README.md
 authors:
-  - Leonardo Andres Gallego <993814+leogallego@users.noreply.github.com>
+  - Leonardo Gallego <993814+leogallego@users.noreply.github.com>
 
 description: Ansible collection for deploying and managing NetBox
 license_file: LICENSE

--- a/plugins/modules/netbox_event_rule.py
+++ b/plugins/modules/netbox_event_rule.py
@@ -197,9 +197,6 @@ from copy import deepcopy
 
 NB_EVENT_RULES = "event_rules"
 
-API_APPS_ENDPOINTS["extras"]["event_rules"] = {}
-ENDPOINT_NAME_MAPPING["event_rules"] = "event_rule"
-
 ACTION_TYPE_TO_ENDPOINT = {
     "webhook": "webhooks",
     "script": "scripts",
@@ -274,6 +271,11 @@ def resolve_action_object(module, nb, data):
 
 def main():
     """Main entry point for module execution."""
+    # TODO(#3): Remove block when event_rules is registered upstream in netbox.netbox
+    API_APPS_ENDPOINTS["extras"]["event_rules"] = {}
+    ENDPOINT_NAME_MAPPING["event_rules"] = "event_rule"
+    # END TODO(#3)
+
     argument_spec = deepcopy(NETBOX_ARG_SPEC)
     argument_spec.update(
         dict(

--- a/tests/unit/plugins/modules/test_netbox_event_rule.py
+++ b/tests/unit/plugins/modules/test_netbox_event_rule.py
@@ -84,14 +84,33 @@ class TestArgumentSpec:
         )
 
     def test_endpoint_registration(self):
-        """Importing the module should patch API_APPS_ENDPOINTS and ENDPOINT_NAME_MAPPING."""
-        from ansible_collections.leogallego.netbox.plugins.modules import (
-            netbox_event_rule,  # noqa: F401 — import triggers side effect
-        )
+        """Calling main() should patch API_APPS_ENDPOINTS and ENDPOINT_NAME_MAPPING."""
         from ansible_collections.netbox.netbox.plugins.module_utils.netbox_utils import (
             API_APPS_ENDPOINTS,
             ENDPOINT_NAME_MAPPING,
         )
+
+        API_APPS_ENDPOINTS["extras"].pop("event_rules", None)
+        ENDPOINT_NAME_MAPPING.pop("event_rules", None)
+
+        from ansible_collections.leogallego.netbox.plugins.modules.netbox_event_rule import (
+            main,
+        )
+
+        with patch(
+            "ansible_collections.leogallego.netbox.plugins.modules.netbox_event_rule.NetboxAnsibleModule"
+        ) as mock_mod_cls, patch(
+            "ansible_collections.leogallego.netbox.plugins.modules.netbox_event_rule.NetboxExtrasModule"
+        ) as mock_extras_cls:
+            mock_instance = MagicMock()
+            mock_instance.params = {
+                "data": {"name": "test", "action_type": "webhook", "action_object_id": 1},
+                "state": "present",
+            }
+            mock_instance.check_mode = False
+            mock_mod_cls.return_value = mock_instance
+            mock_extras_cls.return_value = MagicMock()
+            main()
 
         assert "event_rules" in API_APPS_ENDPOINTS["extras"]
         assert ENDPOINT_NAME_MAPPING["event_rules"] == "event_rule"


### PR DESCRIPTION
## Summary
- Shorten `galaxy.yml` author string from 69 to 61 chars (galaxy-importer limit is 64)
- Move endpoint dict registration from module level into `main()` to avoid `ansible-doc` AST parser failure on `ast.Subscript` nodes
- Mark registration lines with `TODO(#3)` for removal after upstreaming to `netbox.netbox`
- Update `test_endpoint_registration` to exercise registration via `main()` instead of import side-effect

## Test plan
- [x] All 16 unit tests pass locally
- [ ] CI passes (changelog, ansible-lint, sanity, build)

Fixes CI failures introduced in #2.
Tracked by #3 for upstream contribution.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>